### PR TITLE
Allow UploadHandler class and backup_files() to be passed log param

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -17,14 +17,14 @@ import grp
 import signal
 import StringIO
 
-log = logging.getLogger('tablesnap')
+default_log = logging.getLogger('tablesnap')
 stderr = logging.StreamHandler()
 stderr.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
-log.addHandler(stderr)
+default_log.addHandler(stderr)
 if os.environ.get('TDEBUG', False):
-    log.setLevel(logging.DEBUG)
+    default_log.setLevel(logging.DEBUG)
 else:
-    log.setLevel(logging.INFO)
+    default_log.setLevel(logging.INFO)
 
 # Default number of writer threads
 default_threads = 4
@@ -41,13 +41,15 @@ default_chunk_size = 256
 
 class UploadHandler(pyinotify.ProcessEvent):
     def my_init(self, threads=None, key=None, secret=None, bucket_name=None,
-                prefix=None, name=None, max_size=None, chunk_size=None):
+                prefix=None, name=None, max_size=None, chunk_size=None,
+                log=default_log):
         self.key = key
         self.secret = secret
         self.bucket_name = bucket_name
         self.prefix = prefix
         self.name = name or socket.getfqdn()
         self.retries = default_retries
+        self.log = log
 
         if max_size:
             self.max_size = max_size * 2**20
@@ -86,7 +88,7 @@ class UploadHandler(pyinotify.ProcessEvent):
             try:
                 self.upload_sstable(bucket, keyname, f)
             except:
-                log.critical("Failed uploading %s. Aborting.\n%s" %
+                self.log.critical("Failed uploading %s. Aborting.\n%s" %
                              (f, format_exc()))
                 # Brute force kill self
                 os.kill(os.getpid(), signal.SIGKILL)
@@ -108,23 +110,24 @@ class UploadHandler(pyinotify.ProcessEvent):
             try:
                 key = bucket.get_key(keyname)
                 if key == None:
-                    log.debug('Key %s does not exist' % (keyname,))
+                    self.log.debug('Key %s does not exist' % (keyname,))
                     return False
                 else:
-                    log.debug('Found key %s' % (keyname,))
+                    self.log.debug('Found key %s' % (keyname,))
                     break
             except:
                 bucket = self.get_bucket()
                 continue
 
         if key == None:
-            log.critical("Failed to lookup keyname %s after %d retries\n%s" %
-                         (keyname, self.retries, format_exc()))
+            self.log.critical("Failed to lookup keyname %s after %d"
+                              " retries\n%s" %
+                             (keyname, self.retries, format_exc()))
             raise
 
         if key.size != stat.st_size:
-            log.warning('ATTENTION: your source (%s) and target (%s) sizes '
-                'differ, you should take a look. As immutable files '
+            self.log.warning('ATTENTION: your source (%s) and target (%s) '
+                'sizes differ, you should take a look. As immutable files '
                 'never change, one must assume the local file got corrupted '
                 'and the right version is the one in S3. Will skip this file '
                 'to avoid future complications' % (filename, keyname, ))
@@ -138,33 +141,39 @@ class UploadHandler(pyinotify.ProcessEvent):
                     # The file was removed, return True to skip this file.
                     return True
 
-                log.critical("Failed to open file: %s (%s)\n%s" %
+                self.log.critical("Failed to open file: %s (%s)\n%s" %
                              (filename, strerror, format_exc(),))
                 raise
 
             md5 = key.compute_md5(fp)
             fp.close()
-            log.debug('Computed md5: %s' % (md5,))
+            self.log.debug('Computed md5: %s' % (md5,))
 
             meta = key.get_metadata('md5sum')
 
             if meta:
-                log.debug('MD5 metadata comparison: %s == %s? : %s' % (md5[0], meta, (md5[0] == meta)))
+                self.log.debug('MD5 metadata comparison: %s == %s? : %s' %
+                              (md5[0], meta, (md5[0] == meta)))
                 result = (md5[0] == meta)
             else:
-                log.debug('ETag comparison: %s == %s? : %s' % (md5[0], key.etag.strip('"'), (md5[0] == key.etag.strip('"'))))
+                self.log.debug('ETag comparison: %s == %s? : %s' %
+                              (md5[0], key.etag.strip('"'),
+                              (md5[0] == key.etag.strip('"'))))
                 result = (md5[0] == key.etag.strip('"'))
                 if result:
-                    log.debug('Setting missing md5sum metadata for %s' % (keyname,))
+                    self.log.debug('Setting missing md5sum metadata for %s' %
+                                  (keyname,))
                     key.set_metadata('md5sum', md5[0])
         if result:
-            log.info("Keyname %s already exists, skipping upload" % keyname)
+            self.log.info("Keyname %s already exists, skipping upload"
+                          % (keyname))
         else:
-            log.warning('ATTENTION: your source (%s) and target (%s) MD5 '
-                'hashes differ, you should take a look. As immutable files '
-                'never change, one must assume the local file got corrupted '
-                'and the right version is the one in S3. Will skip this file '
-                'to avoid future complications' % (filename, keyname, ))
+            self.log.warning('ATTENTION: your source (%s) and target (%s) '
+                'MD5 hashes differ, you should take a look. As immutable '
+                'files never change, one must assume the local file got '
+                'corrupted and the right version is the one in S3. Will '
+                'skip this file to avoid future complications' % 
+                (filename, keyname, ))
             return True
 
         return result
@@ -182,15 +191,16 @@ class UploadHandler(pyinotify.ProcessEvent):
 
     def split_sstable(self, filename):
         free = self.get_free_memory_in_kb() * 1024
-        log.debug('Free memory check: %d < %d ? : %s' %
+        self.log.debug('Free memory check: %d < %d ? : %s' %
             (free, self.chunk_size, (free < self.chunk_size)))
         if free < self.chunk_size:
-            log.warn('Your system is low on memory, reading in smaller chunks')
+            self.log.warn('Your system is low on memory, '
+                          'reading in smaller chunks')
             chunk_size = free / 20
         else:
             chunk_size = self.chunk_size
-        log.debug('Reading %s in %d byte sized chunks' %
-            (filename, chunk_size))
+        self.log.debug('Reading %s in %d byte sized chunks' %
+                       (filename, chunk_size))
         f = open(filename, 'rb')
         while True:
             chunk = f.read(chunk_size)
@@ -217,12 +227,12 @@ class UploadHandler(pyinotify.ProcessEvent):
         else:
             fp = open(filename, 'rb')
             md5 = boto.utils.compute_md5(fp)
-            log.debug('Computed md5sum before upload is: %s' % (md5,))
+            self.log.debug('Computed md5sum before upload is: %s' % (md5,))
             fp.close()
 
         def progress(sent, total):
             if sent == total:
-                log.info('Finished uploading %s' % filename)
+                self.log.info('Finished uploading %s' % filename)
 
         try:
             dirname = os.path.dirname(filename)
@@ -237,7 +247,8 @@ class UploadHandler(pyinotify.ProcessEvent):
                         break
                     except:
                         if r == self.retries - 1:
-                            log.critical("Failed to upload directory listing.")
+                            self.log.critical("Failed to upload directory "
+                                              "listing.")
                             raise
                         bucket = self.get_bucket()
                         continue
@@ -257,39 +268,44 @@ class UploadHandler(pyinotify.ProcessEvent):
             except:
                 pass
 
-            log.info('Uploading %s' % filename)
+            self.log.info('Uploading %s' % filename)
 
             meta = json.dumps(meta)
 
             for r in range(self.retries):
                 try:
-                    log.debug('File size check: %s > %s ? : %s' %
-                        (stat.st_size, self.max_size, (stat.st_size > self.max_size),))
+                    self.log.debug('File size check: %s > %s ? : %s' %
+                        (stat.st_size, self.max_size,
+                        (stat.st_size > self.max_size),))
                     if stat.st_size > self.max_size:
-                        log.info('Performing multipart upload for %s' % (filename))
+                        self.log.info('Performing multipart upload for %s' %
+                                     (filename))
                         mp = bucket.initiate_multipart_upload(keyname,
                             metadata={'stat': meta, 'md5sum': md5[0]})
                         part = 1
                         chunk = None
                         try:
                             for chunk in self.split_sstable(filename):
-                                log.debug('Uploading part #%d (size: %d)' % (part, chunk.len,))
+                                self.log.debug('Uploading part #%d '
+                                               '(size: %d)' %
+                                               (part, chunk.len,))
                                 mp.upload_part_from_file(chunk, part)
                                 chunk.close()
                                 part += 1
                             part -= 1
                         except Exception as e:
-                            log.debug(e)
-                            log.info('Error uploading part %d' % (part,))
+                            self.log.debug(e)
+                            self.log.info('Error uploading part %d' % (part,))
                             mp.cancel_upload()
                             if chunk:
                                 chunk.close()
                             raise
-                        log.debug('Uploaded %d parts, completing upload' % (part,))
+                        self.log.debug('Uploaded %d parts, '
+                                       'completing upload' % (part,))
                         mp.complete_upload()
                         progress(100, 100)
                     else:
-                        log.debug('Performing monolithic upload')
+                        self.log.debug('Performing monolithic upload')
                         key = bucket.new_key(keyname)
                         key.set_metadata('stat', meta)
                         key.set_metadata('md5sum', md5[0])
@@ -303,17 +319,17 @@ class UploadHandler(pyinotify.ProcessEvent):
                         return
 
                     if r == self.retries - 1:
-                        log.critical("Failed to upload file contents.")
+                        self.log.critical("Failed to upload file contents.")
                         raise
                     bucket = self.get_bucket()
                     continue
 
         except:
-            log.error('Error uploading %s\n%s' % (keyname, format_exc()))
+            self.log.error('Error uploading %s\n%s' % (keyname, format_exc()))
             raise
 
 
-def backup_files(handler, paths):
+def backup_files(handler, paths, log=default_log):
     for path in paths:
         log.info('Backing up %s' % path)
         for filename in os.listdir(path):
@@ -377,7 +393,8 @@ def main():
         ret = wm.add_watch(path, pyinotify.IN_MOVED_TO, rec=options.recursive,
                            auto_add=options.auto_add)
         if ret[path] == -1:
-            log.critical('add_watch failed for %s, bailing out!' % path)
+            default_log.critical('add_watch failed for %s, bailing out!' %
+                                (path))
             return 1
 
     backup_files(handler, paths)


### PR DESCRIPTION
I'm importing tablesnap methods and using them in a larger construct
where it's very useful for me to set up my own logging.  I figure
I may not be the only one.

This could be pushed further by refactoring this into a library and (tiny)
executable but that seemed heavy handed for now.
