### PR TITLE
Add exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ the Debian package, you'll set these options in the `DAEMON_OPTS` variable in
                             Number of writer threads
       -n NAME, --name=NAME  Use this name instead of the FQDN to identify the
                             SSTables from this host
+      -e EXCLUDE, --exclude=EXCLUDE
+                            Exclude files matching this regular expression from
+                            upload (default: -tmp)
       --max-upload-size=MAX_UPLOAD_SIZE
                             Max size for files to be uploaded before doing
                             multipart (default 5120M)

--- a/tablesnap
+++ b/tablesnap
@@ -14,6 +14,7 @@ import sys
 import os
 import pwd
 import grp
+import re
 import signal
 import StringIO
 
@@ -41,11 +42,15 @@ max_file_size = 5120
 # Default chunk size for multipart uploads in MB
 default_chunk_size = 256
 
+# Check if path should be excluded from backup
+def is_excluded(path, rule):
+    return rule and re.search(rule, path)
+
 
 class UploadHandler(pyinotify.ProcessEvent):
     def my_init(self, threads=None, key=None, secret=None, bucket_name=None,
                 prefix=None, name=None, max_size=None, chunk_size=None,
-                log=default_log):
+                log=default_log, exclude=None):
         self.key = key
         self.secret = secret
         self.bucket_name = bucket_name
@@ -53,6 +58,7 @@ class UploadHandler(pyinotify.ProcessEvent):
         self.name = name or socket.getfqdn()
         self.retries = default_retries
         self.log = log
+        self.exclude = exclude
 
         if max_size:
             self.max_size = max_size * 2**20
@@ -74,7 +80,7 @@ class UploadHandler(pyinotify.ProcessEvent):
         return '%s%s:%s' % (self.prefix or '', self.name, pathname)
 
     def add_file(self, filename):
-        if filename.find('-tmp') == -1:
+        if not is_excluded(filename, self.exclude):
             self.fileq.put(filename)
 
     def get_bucket(self):
@@ -332,27 +338,27 @@ class UploadHandler(pyinotify.ProcessEvent):
             raise
 
 
-def backup_file(handler, filename, filedir):
-    if filename.find('-tmp') != -1:
-        return
-
+def backup_file(handler, filename, filedir, exclude):
     fullpath = '%s/%s' % (filedir, filename)
     if os.path.isdir(fullpath):
+        return
+
+    if is_excluded(fullpath, exclude):
         return
 
     handler.add_file(fullpath)
 
 
-def backup_files(handler, paths, recurse, log=default_log):
+def backup_files(handler, paths, recurse, exclude, log=default_log):
     for path in paths:
         log.info('Backing up %s' % path)
         if recurse:
             for root, dirs, files in os.walk(path):
                 for filename in files:
-                    backup_file(handler, filename, root)
+                    backup_file(handler, filename, root, exclude)
         else:
             for filename in os.listdir(path):
-                backup_file(handler, filename, path)
+                backup_file(handler, filename, path, exclude)
     return 0
 
 
@@ -372,6 +378,9 @@ def main():
                       help='Number of writer threads')
     parser.add_option('-n', '--name', dest='name', default=None,
         help='Use this name instead of the FQDN to identify the SSTables from this host')
+    parser.add_option('-e', '--exclude', dest='exclude', default='-tmp',
+        help='Exclude files matching this regular expression from upload '
+             '(default: -tmp)')
     parser.add_option('--max-upload-size', dest='max_upload_size',
         default=max_file_size,
         help='Max size for files to be uploaded before doing multipart '
@@ -398,6 +407,7 @@ def main():
     handler = UploadHandler(threads=options.threads, key=options.aws_key,
                             secret=options.aws_secret, bucket_name=bucket,
                             prefix=options.prefix, name=options.name,
+                            exclude=options.exclude,
                             max_size=int(options.max_upload_size),
                             chunk_size=int(options.multipart_chunk_size))
 
@@ -412,7 +422,7 @@ def main():
             return 1
 
     if options.backup:
-        backup_files(handler, paths, options.recursive)
+        backup_files(handler, paths, options.recursive, options.exclude)
 
     notifier.loop()
 


### PR DESCRIPTION
I've added a `--exclude` option to allow specifying the excluded files. It defaults to `'-tmp'` so it's backwards-compatible. A regex can be provided.

I'm doing this because I want to use the tool for other, non-cassandra, use-cases where that stuff that's being backed up are not SSTables but arbitrary files that get moved to a directory.

Also contains the patch from #17
