### PR TITLE
Enforce uploading with full path in initial uploads.

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -345,7 +345,11 @@ class UploadHandler(pyinotify.ProcessEvent):
 
 
 def backup_file(handler, filename, filedir, exclude):
-    fullpath = '%s/%s' % (filedir, filename)
+    if not filedir.endswith('/'):
+        filedir += '/'
+
+    fullpath = os.path.abspath('%s%s' % (filedir, filename))
+
     if os.path.isdir(fullpath):
         return
 


### PR DESCRIPTION
When passing a relative path to tablesnap, then the initial backup_files
upload will not create the absolute paths of the files in the S3 bucket
whereas the inotify-triggered uploads will.

Say you are in `/home/foo` and `start tablesnap bucket bar/` then initial
files will be uploaded as `hostname:bar/file` whereas the
inotify-triggered files will be uploaded as `hostname:/home/foo/bar/file`

See #18.
