### PR TITLE
Adding argparse to the list of requirements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,5 +7,5 @@ Standards-Version: 3.8.3
 
 Package: tablesnap
 Architecture: any
-Depends: ${python:Depends}, python-pyinotify, python-boto, python-dateutil
+Depends: ${python:Depends}, python-pyinotify, python-boto, python-dateutil, python-argparse
 Description: Uses inotify to monitor Cassandra SSTables and upload them to S3

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     install_requires=[
         'pyinotify',
         'boto>=2.2',
+        'argparse',
     ]
 )


### PR DESCRIPTION
Argparse is provided in the stdlib in python 2.7+, but not in  2.6.
Since lucid still works on 2.6 it makes sense to add this to the
requirements list and also the control file.
