### PR TITLE
tablechop

### DIFF
--- a/tablechop
+++ b/tablechop
@@ -43,38 +43,40 @@ def clean_backups(args, log):
     key_list = sorted(key_list, key=lambda k: dtparser.parse(k.last_modified))
     key_list.reverse() # most recent first
 
-    log.debug("%s keys total", len(key_list))
+    log.info("%s keys total", len(key_list))
 
-    json_files = [x for x in key_list if x.name.endswith('-listdir.json')]
+    json_keys = [x for x in key_list if x.name.endswith('-listdir.json')]
     to_delete = set([x.name for x in key_list]) # we'll remove from this list
 
-    log.debug("%s json listdir files", len(json_files))
+    log.debug("%s json listdir keys", len(json_keys))
 
-    for jfile in json_files:
-        log.debug("file dated : %s (%s)", jfile.last_modified,
-                                            jfile.name.split('/')[-1])
-        if days_ago(jfile.last_modified) > args.age:
+    for jkey in json_keys:
+        log.debug("key dated : %s (%s)", jkey.last_modified,
+                  jkey.name.split('/')[-1])
+        if days_ago(jkey.last_modified) > args.age:
             # We've gone back past our cutoff
-            log.info("reached cutoff at timestamp %s", jfile.last_modified)
+            log.info("reached cutoff at timestamp %s", jkey.last_modified)
             break
-        ky = bucket.get_key(jfile)
+        ky = bucket.get_key(jkey)
         jdict = json.loads(ky.get_contents_as_string())
         if len(jdict.values()) != 1:
             raise SystemError('-listdir.json file should have '
                 'a single key/value pair!')
         # formatting here to match the full 'key' version of filename
         keepers = set(["%s/%s" % (args.path, x) for x in jdict.values()[0]])
-        keepers.add(jfile.name) # keep this json file itself
+        keepers.add(jkey.name) # keep this json file itself
         to_delete = to_delete.difference(keepers)
 
     if args.debug:
-        log.info("%s non-keeper files to delete", len(to_delete))
+        log.debug("%s non-keeper keys to delete", len(to_delete))
         ddates = list(set([x.last_modified[:10] for x in key_list \
                            if x.name in to_delete]))
         ddates.sort()
         log.debug("deletion dates : %s", ddates)
         log.debug("Test mode, nothing deleted")
         return
+
+    log.info("Deleting %s keys" % len(to_delete))
 
     try:
         bucket.delete_keys(to_delete) # !!
@@ -83,19 +85,18 @@ def clean_backups(args, log):
 
     log.info("Keys deleted")
 
-
 def main(log):
     parser = argparse.ArgumentParser(
         description='Clean SSTables from S3. Scroll backwards through '
-        '-listdir.json files in chronological order collecting a "keeper" '
-        'list until it reaches it\'s age cutoff. Deletes all files not in that '
+        '-listdir.json keys in chronological order collecting a "keeper" '
+        'list until it reaches it\'s age cutoff. Deletes all keys not in that '
         'list')
     parser.add_argument(
         '-d',
         '--debug',
         dest='debug',
         action='store_true',
-        help='Run in debug mode, will not delete files. Implies -v')
+        help='Run in debug mode, will not delete keys. Implies -v')
     parser.add_argument(
         '-k',
         '--key',


### PR DESCRIPTION
Hi there! We realized we were accumulating a pretty sizable set of files in S3, and needed a way to keep them trimmed down. As described in tablechop -h : 

Clean SSTables from S3. Scrolls backwards through -listdir.json keys in chronological order collecting a "keeper" list until it reaches it's age cutoff. Deletes all keys not in that list.

I've been running in QA with -a 30 (30 days of backup) and have tested by tableslurp-ing and restoring files to be sure I wasn't deleting anything I shouldn't be.

Feedback welcome, thanks.
