### PR TITLE
Make sure all S3 keys are listed

### DIFF
--- a/tableslurp
+++ b/tableslurp
@@ -115,7 +115,7 @@ class DownloadHandler(object):
                 (self.prefix, target_file))
 #       Otherwise try to fetch the most recent one
         else:
-            keys = [_ for _ in bucket.get_all_keys(prefix='%s/' %
+            keys = [_ for _ in bucket.list(prefix='%s/' %
                 (self.prefix,)) if _.name.endswith('-listdir.json')]
             if keys:
                 keys.sort(key=lambda l: parser.parse(l.last_modified))


### PR DESCRIPTION
Changed tableslurp to use bucket.list instead of bucket.get_all_keys so that all keys in a bucket gets listed and not only the first X (1000 by default according to http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html).
