### PR TITLE
Update tablesnap.init to include LSB header

### DIFF
--- a/debian/tablesnap.init
+++ b/debian/tablesnap.init
@@ -10,6 +10,15 @@
 #
 # Version:	@(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
 #
+### BEGIN INIT INFO
+# Provides:          tablesnap
+# Required-Start:    $syslog
+# Required-Stop:     $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: tablesnap
+# Description:       Starts Tablesnap,for saving Cassandra data to S3
+### END INIT INFO
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/tablesnap


### PR DESCRIPTION
Seem like sane defaults, quiets error that has upon install of debuild generated package.
