### PR TITLE
Remove requirement for aws keys since boto can use IAM roles.

### DIFF
--- a/tablechop
+++ b/tablechop
@@ -116,13 +116,11 @@ def main(log):
     parser.add_argument(
         '-k',
         '--key',
-        required=True,
         dest='key',
         help='Amazon S3 Key')
     parser.add_argument(
         '-s',
         '--secret',
-        required=True,
         dest='secret',
         help='Amazon S3 Secret')
     parser.add_argument(

--- a/tableslurp
+++ b/tableslurp
@@ -252,10 +252,8 @@ def main():
         'code is straightforward, the program assumes the files you are '
         'restoring got previously backed up with `tablesnap`',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    ap.add_argument('-k', '--aws-key',
-        required=True, help='Amazon S3 key')
-    ap.add_argument('-s', '--aws-secret',
-        required=True, help='Amazon S3 secret')
+    ap.add_argument('-k', '--aws-key', help='Amazon S3 key')
+    ap.add_argument('-s', '--aws-secret', help='Amazon S3 secret')
     ap.add_argument('-p', '--preserve', default=False, action='store_true',
         help='Preserve the permissions (if they exist) from the source. '
         'This overrides -o and -g')

--- a/tablesnap
+++ b/tablesnap
@@ -416,8 +416,8 @@ def main():
         'the time of the copy.')
     parser.add_argument('bucket', help='S3 bucket')
     parser.add_argument('paths', nargs='+', help='Paths to be watched')
-    parser.add_argument('-k', '--aws-key', required=True)
-    parser.add_argument('-s', '--aws-secret', required=True)
+    parser.add_argument('-k', '--aws-key')
+    parser.add_argument('-s', '--aws-secret')
     parser.add_argument('-r', '--recursive', action='store_true',
         default=False,
         help='Recursively watch the given path(s)s for new SSTables')


### PR DESCRIPTION
The table\* tools don't need to require aws keys as arguments if an IAM role exists on the instance. The underlying boto library will automagically detect this and use the instance keys if none are provided. 
