### PR TITLE
add one-shot mode to exit after backing up snapshot

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -472,6 +472,9 @@ def main():
         help='Chunk size for multipart uploads (default: %dM or 10%%%% of '
              'free memory if default is not available)' % default_chunk_size)
 
+    parser.add_argument('--one-shot', action='store_true', default=False,
+            help='Process backup and exit')
+
     args = parser.parse_args()
 
     # For backwards-compatibility: If neither exclude nor include are set,
@@ -512,6 +515,10 @@ def main():
 
     if args.backup:
         backup_files(handler, args.paths, args.recursive, include)
+
+    if args.one_shot:
+        default_log.info('Backup complete, exiting due to one-shot')
+        sys.exit(0)
 
     notifier.loop()
 


### PR DESCRIPTION
Not sure if this is useful to others, however it is minimally invasive and simply exits before `notifier.loop()` is called.

I'm using this to backup snapshots under LevelledCompaction where sending each rewritten SSTable to s3 isn't prudent.
