### PR TITLE
Only upload index files once per SSTable

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -252,6 +252,12 @@ class UploadHandler(pyinotify.ProcessEvent):
         if f and not f.closed:
             f.close()
 
+    def should_create_index(self, filename):
+        """ Should we upload a JSON index for this file? Cassandra
+            SSTables are composed of six files, so only generate a
+            JSON file when we upload a .Data.db file. """
+        return ("Data.db" in filename)
+
     def upload_sstable(self, bucket, keyname, filename):
 
         # Include the file system metadata so that we have the
@@ -281,7 +287,7 @@ class UploadHandler(pyinotify.ProcessEvent):
 
         try:
             dirname = os.path.dirname(filename)
-            if self.with_index:
+            if self.with_index and self.should_create_index(filename):
                 listdir = []
                 for listfile in os.listdir(dirname):
                     if self.include is None or (self.include is not None


### PR DESCRIPTION
Cassandra SSTables consist of six files on disk. When a new one is created, tablesnap uploads six index files as well. This is fairly pointless and increases the number of files that tablechop has to fetch and parse significantly.

On one of our machines which has been running tablesnap for a week tablechop is currently taking >12 hours to run - the majority of the time taken is fetching index files (we use LeveledCompactionStrategy which probably exacerbates this):

```
tablechop [2015-08-03 15:03:18,270] INFO 79397 keys total
tablechop [2015-08-03 15:03:18,270] DEBUG 39702 json listdir keys
```

This patch only generates a new index file for each `Data.db` file.