### PR TITLE
Allow an S3 region to be specified

### DIFF
--- a/tablechop
+++ b/tablechop
@@ -33,9 +33,10 @@ def clean_backups(args, log):
         args.name = socket.getfqdn()
 
     try:
-        s3conn = boto.connect_s3(aws_access_key_id=args.key,
-                                 aws_secret_access_key=args.secret,
-                                 security_token=args.token)
+        s3conn = boto.s3.connect_to_region(args.aws_region,
+                                           aws_access_key_id=args.key,
+                                           aws_secret_access_key=args.secret,
+                                           security_token=args.token)
         bucket = s3conn.get_bucket(args.bucket)
     except boto.exception.BotoServerError, e:
         log.error('Problem initializing S3 connection: %s', e)
@@ -163,6 +164,10 @@ def main(log):
     parser.add_argument('--token',
         default=os.environ.get('AWS_SECURITY_TOKEN'),
         help='Amazon S3 Token (default from AWS_SECURITY_TOKEN in environment)')
+    parser.add_argument('--aws-region',
+        default='us-east-1',
+        choices=[region.name for region in boto.s3.regions()],
+        help='AWS region to connect to.')
     parser.add_argument(
         '-n',
         '--name',

--- a/tableslurp
+++ b/tableslurp
@@ -76,6 +76,7 @@ class DownloadHandler(object):
         self.preserve = args.preserve
         self.key = args.aws_key
         self.secret = args.aws_secret
+        self.region = args.aws_region
         self.token = args.token
         self.bucket_name = args.bucket[0]
         self.num_threads = args.threads
@@ -103,13 +104,15 @@ class DownloadHandler(object):
 #       unsure if boto is thread-safe, will reconnect every time
         log.debug('Connecting to s3')
         if self.token:
-            conn = boto.connect_s3(aws_access_key_id=self.key,
-                                   aws_secret_access_key=self.secret,
-                                   security_token=self.token)
+            conn = boto.s3.connect_to_region(self.region,
+                                             aws_access_key_id=self.key,
+                                             aws_secret_access_key=self.secret,
+                                             security_token=self.token)
         else:
-            conn = boto.connect_s3(aws_access_key_id=self.key,
-                                   aws_secret_access_key=self.secret,
-                                   security_token=self.token)
+            conn = boto.s3.connect_to_region(self.region,
+                                             aws_access_key_id=self.key,
+                                             aws_secret_access_key=self.secret,
+                                             security_token=self.token)
 
         bucket = conn.get_bucket(self.bucket_name)
         log.debug('Connected to s3')
@@ -282,6 +285,10 @@ def main():
     ap.add_argument('--token',
         default=os.environ.get('AWS_SECURITY_TOKEN'),
         help='Amazon S3 Token (default from AWS_SECURITY_TOKEN in environment)')
+    ap.add_argument('--aws-region',
+        default='us-east-1',
+        choices=[region.name for region in boto.s3.regions()],
+        help='AWS region to connect to.')
     ap.add_argument('-p', '--preserve', default=False, action='store_true',
         help='Preserve the permissions (if they exist) from the source. '
         'This overrides -o and -g')

--- a/tablesnap
+++ b/tablesnap
@@ -56,7 +56,7 @@ default_chunk_size = 256
 default_listen_event = 'IN_MOVED_TO'
 
 class UploadHandler(pyinotify.ProcessEvent):
-    def my_init(self, threads=None, key=None, secret=None, token=None,
+    def my_init(self, threads=None, key=None, secret=None, token=None, region=None,
                 bucket_name=None,
                 prefix=None, name=None, max_size=None, chunk_size=None,
                 include=None,
@@ -68,6 +68,7 @@ class UploadHandler(pyinotify.ProcessEvent):
         self.key = key
         self.secret = secret
         self.token = token
+        self.region = region
         self.bucket_name = bucket_name
         self.prefix = prefix
         self.name = name or socket.getfqdn()
@@ -109,12 +110,14 @@ class UploadHandler(pyinotify.ProcessEvent):
     def get_bucket(self):
         # Reconnect to S3
         if self.token:
-            s3 = boto.connect_s3(aws_access_key_id=self.key,
-                                 aws_secret_access_key=self.secret,
-                                 security_token=self.token)
+            s3 = boto.s3.connect_to_region(self.region,
+                                           aws_access_key_id=self.key,
+                                           aws_secret_access_key=self.secret,
+                                           security_token=self.token)
         else:
-            s3 = boto.connect_s3(aws_access_key_id=self.key,
-                                 aws_secret_access_key=self.secret)
+            s3 = boto.s3.connect_to_region(self.region,
+                                           aws_access_key_id=self.key,
+                                           aws_secret_access_key=self.secret)
 
         return s3.get_bucket(self.bucket_name)
 
@@ -444,6 +447,10 @@ def main():
     parser.add_argument('-s', '--aws-secret',
         default=os.environ.get('AWS_SECRET_ACCESS_KEY'),
         help='Amazon S3 Secret (default from AWS_SECRET_ACCESS_KEY in environment)')
+    parser.add_argument('--aws-region',
+        default='us-east-1',
+        choices=[region.name for region in boto.s3.regions()],
+        help='AWS region to connect to.')
     parser.add_argument('--aws-token',
         default=os.environ.get('AWS_SECURITY_TOKEN'),
         help='Amazon S3 Token (default from AWS_SECURITY_TOKEN in environment)')
@@ -507,16 +514,19 @@ def main():
     # potential thread-safety problems.
 
     if args.aws_token:
-        s3 = boto.connect_s3(aws_access_key_id=args.aws_key,
-                             aws_secret_access_key=args.aws_secret,
-                             security_token=args.aws_token)
+        s3 = boto.s3.connect_to_region(args.aws_region,
+                                       aws_access_key_id=args.aws_key,
+                                       aws_secret_access_key=args.aws_secret,
+                                       security_token=args.aws_token)
     else:
-        s3 = boto.connect_s3(aws_access_key_id=args.aws_key,
-                             aws_secret_access_key=args.aws_secret)
+        s3 = boto.s3.connect_to_region(args.aws_region,
+                                       aws_access_key_id=args.aws_key,
+                                       aws_secret_access_key=args.aws_secret)
     bucket = s3.get_bucket(args.bucket)
 
     handler = UploadHandler(threads=args.threads, key=args.aws_key,
                             secret=args.aws_secret, token=args.aws_token,
+                            region=args.aws_region,
                             bucket_name=bucket,
                             prefix=args.prefix, name=args.name,
                             include=include,


### PR DESCRIPTION
This change allows a specific S3 region to be passed to tablesnap. The default remains us-east-1 (a.k.a. us-standard).

This is especially important if your Cassandra nodes are in a private VPC subnet behind a NAT gateway. Bandwidth through a NAT gateway, I recently found out, costs a lot of money so it's prudent to communicate with S3 through a [VPC Endpoint](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-endpoints.html).

VPC endpoints are only used if your bucket is in the same region and you're communicating directly with the local S3 endpoint, so it's preferable to be quite sure this is the case.

It's possible that Boto does this automatically in later versions, but I couldn't make it reliably work in my testing. I enjoy the peace of mind that an explicit setting provides, when the alternative is NAT gateway bills.