### PR TITLE
Allow tablesnap to include listening to IN_CREATE 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ optional arguments:
                         into upload.WARNING: If neither exclude nor include
                         are defined, then all files matching "-tmp" are
                         excluded.
-  --listen-events {IN_MOVED_TO,IN_CLOSE_WRITE}
+  --listen-events {IN_MOVED_TO,IN_CLOSE_WRITE,IN_CREATE}
                         Which events to listen on, can be specified multiple
-                        times. Values: IN_MOVED_TO (default), IN_CLOSE_WRITE
+                        times. Values: IN_MOVED_TO, IN_CLOSE_WRITE, IN_CREATE
+                        (default: IN_MOVED_TO, IN_CLOSE_WRITE)
   --max-upload-size MAX_UPLOAD_SIZE
                         Max size for files to be uploaded before doing
                         multipart (default 5120M)

--- a/tablesnap
+++ b/tablesnap
@@ -145,6 +145,8 @@ class UploadHandler(pyinotify.ProcessEvent):
     def process_IN_MOVED_TO(self, event):
         self.add_file(event.pathname)
 
+    def process_IN_CREATE(self, event):
+        self.add_file(event.pathname)
     #
     # Check if this keyname (ie, file) has already been uploaded to
     # the S3 bucket. This will verify that not only does the keyname
@@ -487,9 +489,9 @@ def main():
         help='If you want to compute *every file* for its MD5 checksum at '
              'start time, enable this option.')
     parser.add_argument('--listen-events', action='append',
-        choices=['IN_MOVED_TO', 'IN_CLOSE_WRITE'],
+        choices=['IN_MOVED_TO', 'IN_CLOSE_WRITE', 'IN_CREATE'],
         help='Which events to listen on, can be specified multiple times. '
-             'Values: IN_MOVED_TO, IN_CLOSE_WRITE (default both)')
+             'Values: IN_MOVED_TO, IN_CLOSE_WRITE, IN_CREATE (default IN_MOVED_TO, IN_CLOSE_WRITE)')
 
     include_group = parser.add_mutually_exclusive_group()
     include_group.add_argument('-e', '--exclude', default=None,


### PR DESCRIPTION
Hi Jeremy, 

This is a simple PR to allow tablesnap to also be able to watch for IN_CREATE events, which can be useful for commitlog_archiving. With commitlog_archiving, the typical command is to create a hard link once the CLog is full; however with the current inotify events it does not see it: 

`archive_command: /bin/ln %path /backup/%name`

Having tablesnap watch the /backup directory, everytime there is a new link...nothing happens. If the command was `/bin/cp`, it works (but that will incur a performance impact)

From my own debugging, it seems like the event is `IN_CREATE`:

```
<Event dir=False mask=0x100 maskname=IN_CREATE name=sigh.txt path=/cassandra/commitlog_archive pathname=/cassandra/commitlog_archive/sigh.txt wd=1 >
```

This will make tablesnap useful for backing up CLogs as well, WDYT? I tested it on my test cluster. 

Thanks! 