### PR TITLE
Make tableslurp able to restore recursively

### DIFF
--- a/tableslurp
+++ b/tableslurp
@@ -29,6 +29,8 @@ import pwd
 import socket
 import sys
 from Queue import Queue
+import re
+from datetime import datetime
 
 log = logging.getLogger('tableslurp')
 stderr = logging.StreamHandler()
@@ -39,6 +41,111 @@ if os.environ.get('TDEBUG', False):
     log.setLevel(logging.DEBUG)
 else:
     log.setLevel(logging.INFO)
+
+clog_regex = re.compile('CommitLog-\d-(\d+).log')
+
+
+def parse_clog(clog):
+    return clog_regex.search(clog).group(1)
+
+
+def get_bucket(region, key, secret, token, bucket_name):
+#   unsure if boto is thread-safe, will reconnect every time
+    log.debug('Connecting to s3')
+    if token:
+        conn = boto.s3.connect_to_region(region,
+                                         aws_access_key_id=key,
+                                         aws_secret_access_key=secret,
+                                         security_token=token)
+    else:
+        conn = boto.s3.connect_to_region(region,
+                                         aws_access_key_id=key,
+                                         aws_secret_access_key=secret,
+                                         security_token=token)
+
+    bucket = conn.get_bucket(bucket_name)
+    log.debug('Connected to s3')
+    return bucket
+
+
+def find_latest_listdirjson_for_every_table(bucket, prefix):
+    latest_listdirjsons={}
+    # Get all ks folders, e.g /var/lib/cassandra/<ks>
+    keyspace_dirs = [_.name for _ in list(bucket.list(prefix='%s/' % prefix, delimiter='/'))]
+
+    for keyspace_dir in keyspace_dirs:
+        # Get all tbl folders for every ks folder, e.g /var/lib/cassandra/<ks>/<tbl>
+        table_dirs = [_.name for _ in list(bucket.list(prefix=keyspace_dir, delimiter='/'))]
+
+        for table_dir in table_dirs:
+            # Get all listdir.json files for every tbl folder,
+            # e.g /var/lib/cassandra/<ks>/<tbl>/mc-1/2/3/4...-Data.db-listdir.json
+            keys = [_ for _ in bucket.list(prefix=table_dir, delimiter='/') if _.name.endswith('-listdir.json')]
+
+            if keys:
+                keys.sort(key=lambda l: parser.parse(l.last_modified))
+                key = keys.pop()
+                table = table_dir.replace('%s/' % prefix, '').rstrip('/')
+                latest_listdirjsons[table] = key
+    return latest_listdirjsons
+
+
+def build_recursive_fileset(bucket, prefix):
+    table_to_latest_listdirjson_mapping = find_latest_listdirjson_for_every_table(bucket, prefix)
+    table_to_files_mapping = {}
+
+    for table, listdirjson in table_to_latest_listdirjson_mapping.items():
+        json_data = json.loads(listdirjson.get_contents_as_string())
+        # There should only ever be one latest listdir.json and hence, one set of (latest) SSTables
+        sstables = json_data.itervalues().next()
+        table_to_files_mapping[table] = sstables
+        log.info("Found %s with %d files", table, len(sstables))
+
+    return table_to_files_mapping
+
+
+def build_clog_fileset(bucket, prefix, clog_prefix):
+    fileset=[]
+    table_to_latest_listdirjson_mapping = find_latest_listdirjson_for_every_table(bucket, prefix)
+    listdirjsons = table_to_latest_listdirjson_mapping.values()
+    listdirjsons.sort(key=lambda l: parser.parse(l.last_modified), reverse=True)
+    oldest_key = listdirjsons.pop()
+    oldest_timestamp = datetime.strptime(oldest_key.last_modified, "%Y-%m-%dT%H:%M:%S.%fZ").strftime('%s')
+    oldest_timestamp_ms = int(oldest_timestamp) * 1000
+    clogs = [_.name for _ in bucket.list(prefix='%s/' % clog_prefix)]
+    clogs.sort(reverse=True)
+    for clog in clogs:
+        if parse_clog(clog) > oldest_timestamp_ms:
+            fileset.append(clog.replace('%s/' % clog_prefix, '').rstrip('/'))
+        else:
+            break
+    return fileset
+
+
+def build_single_fileset(bucket, prefix, origin, target_file):
+    key = None
+    # If you want to restore a fileset in particular
+    if target_file:
+        key = bucket.get_key('%s/%s-listdir.json' %
+                             (prefix, target_file))
+
+    else:
+        prefix_part_count = prefix.count('/') + 1
+        keys = [_ for _ in bucket.list(prefix='%s/' %
+                                              (prefix,)) if
+                _.name.endswith('-listdir.json') and _.name.count('/') == prefix_part_count]
+        if keys:
+            keys.sort(key=lambda l: parser.parse(l.last_modified))
+            key = keys.pop()
+
+    if not key:
+        raise LookupError('Cannot find anything to restore from %s:%s/%s' %
+                          (bucket.name, prefix, target_file or ''))
+
+    json_data = json.loads(key.get_contents_as_string())
+    fileset = json_data[origin]
+    log.info('Fileset contains %d files to download' % (len(fileset)))
+    return fileset
 
 
 class DownloadCounter(object):
@@ -70,8 +177,8 @@ class DownloadHandler(object):
     num_threads = 4
     threads = {}
 
-    def __init__(self, args):
-        self.target = args.target[0]
+    def __init__(self, args=None, target=None, prefix=None, fileset=None):
+        self.target = target
         self.origin = args.origin[0]
         self.preserve = args.preserve
         self.key = args.aws_key
@@ -83,10 +190,11 @@ class DownloadHandler(object):
         self.force = args.force
         if args.name:
             self.name = args.name
-        self.prefix = '%s:%s' % (self.name, self.origin)
+        self.prefix = prefix
+        self.fileset=fileset
 
 #       It may be a bit sub-optimal, but I rather fail sooner than later
-        (owner, group) = self._build_file_set(args.file)
+        (owner, group) = self._check_metadata()
 
         if not self.preserve:
             owner = args.owner
@@ -101,48 +209,10 @@ class DownloadHandler(object):
                 (owner, group,))
 
     def _get_bucket(self):
-#       unsure if boto is thread-safe, will reconnect every time
-        log.debug('Connecting to s3')
-        if self.token:
-            conn = boto.s3.connect_to_region(self.region,
-                                             aws_access_key_id=self.key,
-                                             aws_secret_access_key=self.secret,
-                                             security_token=self.token)
-        else:
-            conn = boto.s3.connect_to_region(self.region,
-                                             aws_access_key_id=self.key,
-                                             aws_secret_access_key=self.secret,
-                                             security_token=self.token)
+        return get_bucket(self.region, self.key, self.secret, self.token, self.bucket_name)
 
-        bucket = conn.get_bucket(self.bucket_name)
-        log.debug('Connected to s3')
-        return bucket
-
-    def _build_file_set(self, target_file=None):
-        log.info('Building fileset')
-        key = None
-#       If you want to restore a file-set in particular
+    def _check_metadata(self):
         bucket = self._get_bucket()
-        if target_file:
-            key = bucket.get_key('%s/%s-listdir.json' %
-                (self.prefix, target_file))
-#       Otherwise try to fetch the most recent one
-        else:
-            prefix_part_count = self.prefix.count('/') + 1
-            keys = [_ for _ in bucket.list(prefix='%s/' %
-                (self.prefix,)) if _.name.endswith('-listdir.json') and _.name.count('/') == prefix_part_count]
-            if keys:
-                keys.sort(key=lambda l: parser.parse(l.last_modified))
-                key = keys.pop()
-
-        if not key:
-            raise LookupError('Cannot find anything to restore from %s:%s/%s' %
-                (bucket.name, self.prefix, target_file or ''))
-
-        json_data = json.loads(key.get_contents_as_string())
-        self.fileset = json_data[self.origin]
-        log.info('Fileset contains %d files to download' % (len(self.fileset)))
-
         for fileset in self.fileset:
             k = bucket.get_key('%s/%s' % (self.prefix, fileset))
             if k is not None:
@@ -207,7 +277,7 @@ class DownloadHandler(object):
                 #Retry downloading until we succeed
                 try:
                     key = bucket.get_key(keypath)
-                    log.debug('Key objectd is %s' % key)
+                    log.debug('Key object is %s' % key)
                     if os.path.isfile(destfile):
                         stat = os.stat(destfile)
                         if self.force:
@@ -302,9 +372,16 @@ def main():
         help='After download, chgrp files to this group.')
     ap.add_argument('-t', '--threads', type=int, default=4,
         help='Split the download between this many threads')
-    ap.add_argument('-f', '--file',
+    include_group = ap.add_mutually_exclusive_group()
+    include_group.add_argument('-f', '--file',
         help='If specified, will download the file-set this file belongs to '
         'instead of the latest one available.')
+    include_group.add_argument('-r', '--recursive', default=False, action='store_true',
+        help='Recursively download the files at the given origin (path), using latest ones available.')
+    include_group.add_argument('--commitlogs',
+        help='Download commitlogs, assuming up to the most recent batch possible. \n'
+             'If your bucket structure is <fqdn or name>/var/lib/cassandra/commitlog \n'
+             'provide /var/lib/cassandra/commitlog. \n')
     ap.add_argument('--force', default=False, action='store_true',
         help='Force download files even if they exist')
     ap.add_argument('-n', '--name', default=socket.getfqdn(),
@@ -313,12 +390,34 @@ def main():
         help='S3 bucket to download files from')
     ap.add_argument('origin', nargs=1,
         help='Path inside the bucket to the directory you want to download '
-        'files from')
+             'files from. '
+             'E.g if your bucket structure is <fqdn or name>/var/lib/cassandra/data/<ks>/<tbl>/<files>. \n'
+             'With --recursive or --commitlogs, you should provide /var/lib/cassandra/data. \n'
+             'Otherwise, provide /var/lib/cassandra/data/<ks>/<tbl> if you want to restore just one table.')
     ap.add_argument('target', nargs=1,
         help='Path in the local FS where files should be downloaded to')
     args = ap.parse_args()
-    dh = DownloadHandler(args)
-    dh.run()
+
+    prefix='%s:%s' % (args.name, args.origin[0])
+    bucket=get_bucket(args.aws_region, args.aws_key, args.aws_secret, args.token, args.bucket[0])
+    log.info('Building fileset')
+    if args.recursive:
+        table_to_files_mapping=build_recursive_fileset(bucket, prefix)
+        for table,fileset in table_to_files_mapping.iteritems():
+            dh = DownloadHandler(args, target=os.path.join(args.target[0], table),
+                                 prefix=os.path.join(prefix, table), fileset=fileset)
+            dh.run()
+    elif args.commitlogs:
+        clog_prefix = '%s:%s' % (args.name, args.commitlogs)
+        fileset = build_clog_fileset(bucket, prefix, clog_prefix)
+        dh = DownloadHandler(args, target=os.path.join(args.target[0]), prefix=clog_prefix,
+                             fileset=fileset)
+        dh.run()
+    else:
+        fileset=build_single_fileset(bucket, prefix, args.origin[0], args.file)
+        dh = DownloadHandler(args, target=args.target[0], prefix=prefix,
+                             fileset=fileset)
+        dh.run()
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/tableslurp
+++ b/tableslurp
@@ -213,6 +213,7 @@ class DownloadHandler(object):
 
     def _check_metadata(self):
         bucket = self._get_bucket()
+        k = None
         for fileset in self.fileset:
             k = bucket.get_key('%s/%s' % (self.prefix, fileset))
             if k is not None:


### PR DESCRIPTION
Hello!

This commit makes tableslurp able to restore recursively based on the origin provided. I've tried to make it backwards compatible so it keeps it's original behaviour in case there are others using it. I'm not good with Python and I don't know Pythonic ways of doing things so comments are welcome. 

Basically, it introduces a `--recursive` flag, and for every found table it will create a `DownloadHandler`, let that run to completion, then move on to the next table. An example: 

```
tableslurp -n 172.31.9.86 --recursive --aws-region ap-northeast-2 lerhtest /cassandra/data backuptest/
tableslurp [2017-10-17 02:04:20,356] INFO Building fileset
tableslurp [2017-10-17 02:04:20,481] INFO Found restoretest/ledger-c2e4a3a0b21911e789d4671ea19485f1 with 25 files
tableslurp [2017-10-17 02:04:20,516] INFO Found restoretest/perks-c375e720b21911e789d4671ea19485f1 with 25 files
tableslurp [2017-10-17 02:04:20,616] INFO Found system/compaction_history-b4dbb7b4dc493fb5b3bfce6e434832ca with 17 files
tableslurp [2017-10-17 02:04:20,654] INFO Found system/local-7ad54392bcdd35a684174e047860b377 with 17 files
tableslurp [2017-10-17 02:04:20,691] INFO Found system/paxos-b7b7f0c2fd0a34108c053ef614bb7c2d with 9 files
tableslurp [2017-10-17 02:04:20,740] INFO Found system/peers-37f71aca7dc2383ba70672528af04d4f with 35 files
tableslurp [2017-10-17 02:04:20,807] INFO Found system/size_estimates-618f817b005f3678b8a453f3930b8e86 with 17 files
tableslurp [2017-10-17 02:04:20,863] INFO Found system/sstable_activity-5a1ff267ace03f128563cfae6103c65e with 9 files
tableslurp [2017-10-17 02:04:20,907] INFO Found system_schema/aggregates-924c55872e3a345bb10c12f37c1ba895 with 9 files
tableslurp [2017-10-17 02:04:20,953] INFO Found system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f with 25 files
tableslurp [2017-10-17 02:04:20,985] INFO Found system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f with 9 files
tableslurp [2017-10-17 02:04:21,029] INFO Found system_schema/functions-96489b7980be3e14a70166a0b9159450 with 9 files
tableslurp [2017-10-17 02:04:21,059] INFO Found system_schema/indexes-0feb57ac311f382fba6d9024d305702f with 9 files
tableslurp [2017-10-17 02:04:21,106] INFO Found system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6 with 25 files
tableslurp [2017-10-17 02:04:21,162] INFO Found system_schema/tables-afddfb9dbc1e30688056eed6c302ba09 with 25 files
tableslurp [2017-10-17 02:04:21,196] INFO Found system_schema/triggers-4df70b666b05325195a132b54005fd48 with 9 files
tableslurp [2017-10-17 02:04:21,238] INFO Found system_schema/types-5a8b1ca866023f77a0459273d308917a with 9 files
tableslurp [2017-10-17 02:04:21,280] INFO Found system_schema/views-9786ac1cdd583201a7cdad556410c985 with 9 files
tableslurp [2017-10-17 02:04:21,349] INFO Will now try to test writing to the target dir backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48
tableslurp [2017-10-17 02:04:21,349] INFO Will write to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48
tableslurp [2017-10-17 02:04:21,349] INFO Running
tableslurp [2017-10-17 02:04:21,349] INFO Pushing file mc-5-big-Digest.crc32 onto queue
tableslurp [2017-10-17 02:04:21,349] INFO Pushing file mc-5-big-Data.db onto queue
tableslurp [2017-10-17 02:04:21,349] INFO Pushing file mc-5-big-TOC.txt onto queue
tableslurp [2017-10-17 02:04:21,349] INFO Pushing file mc-5-big-Summary.db onto queue
tableslurp [2017-10-17 02:04:21,349] INFO Pushing file mc-5-big-Filter.db onto queue
tableslurp [2017-10-17 02:04:21,349] INFO Pushing file mc-5-big-Statistics.db onto queue
tableslurp [2017-10-17 02:04:21,350] INFO Pushing file mc-5-big-CompressionInfo.db onto queue
tableslurp [2017-10-17 02:04:21,350] INFO Pushing file mc-5-big-Index.db onto queue
tableslurp [2017-10-17 02:04:21,350] INFO Pushing file backups onto queue
tableslurp [2017-10-17 02:04:21,350] INFO Thread #0 processing items
tableslurp [2017-10-17 02:04:21,351] INFO Thread #1 processing items
tableslurp [2017-10-17 02:04:21,351] INFO Thread #2 processing items
tableslurp [2017-10-17 02:04:21,353] INFO Thread #3 processing items
tableslurp [2017-10-17 02:04:21,393] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Digest.crc32 from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Digest.crc32
tableslurp [2017-10-17 02:04:21,406] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-TOC.txt from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-TOC.txt
tableslurp [2017-10-17 02:04:21,418] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Summary.db from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Summary.db
tableslurp [2017-10-17 02:04:21,420] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Data.db from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Data.db
tableslurp [2017-10-17 02:04:21,456] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Filter.db from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Filter.db
tableslurp [2017-10-17 02:04:21,464] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Statistics.db from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Statistics.db
tableslurp [2017-10-17 02:04:21,468] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-CompressionInfo.db from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-CompressionInfo.db
tableslurp [2017-10-17 02:04:21,478] INFO Downloading 172.31.9.86:/cassandra/data/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Index.db from lerhconsultest to backuptest/system_schema/triggers-4df70b666b05325195a132b54005fd48/mc-5-big-Index.db
tableslurp [2017-10-17 02:04:21,485] INFO Thread #0 finished processing
tableslurp [2017-10-17 02:04:21,502] INFO Thread #3 finished processing
tableslurp [2017-10-17 02:04:21,503] INFO Thread #2 finished processing
tableslurp [2017-10-17 02:04:21,503] INFO Thread #1 finished processing
tableslurp [2017-10-17 02:04:21,503] INFO My job is done.
tableslurp [2017-10-17 02:04:21,552] INFO Will now try to test writing to the target dir backuptest/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6
tableslurp [2017-10-17 02:04:21,553] INFO Will write to backuptest/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6
tableslurp [2017-10-17 02:04:21,553] INFO Running
tableslurp [2017-10-17 02:04:21,553] INFO Pushing file mc-9-big-TOC.txt onto queue
tableslurp [2017-10-17 02:04:21,553] INFO Pushing file mc-10-big-TOC.txt onto queue
tableslurp [2017-10-17 02:04:21,553] INFO Pushing file mc-11-big-Data.db onto queue
tableslurp [2017-10-17 02:04:21,553] INFO Pushing file mc-10-big-Index.db onto queue
....and so on. 
```

The end result is:
```
ubuntu@ip-172-31-9-86:~$ ls backuptest/
restoretest/   system/        system_schema/
ubuntu@ip-172-31-9-86:~$ ls backuptest/restoretest/
ledger-c2e4a3a0b21911e789d4671ea19485f1/ perks-c375e720b21911e789d4671ea19485f1/
ubuntu@ip-172-31-9-86:~$ ls backuptest/restoretest/ledger-c2e4a3a0b21911e789d4671ea19485f1/mc-
mc-1-big-CompressionInfo.db  mc-1-big-Index.db            mc-2-big-CompressionInfo.db  mc-2-big-Index.db            mc-3-big-CompressionInfo.db  mc-3-big-Index.db
mc-1-big-Data.db             mc-1-big-Statistics.db       mc-2-big-Data.db             mc-2-big-Statistics.db       mc-3-big-Data.db             mc-3-big-Statistics.db
mc-1-big-Digest.crc32        mc-1-big-Summary.db          mc-2-big-Digest.crc32        mc-2-big-Summary.db          mc-3-big-Digest.crc32        mc-3-big-Summary.db
mc-1-big-Filter.db           mc-1-big-TOC.txt             mc-2-big-Filter.db           mc-2-big-TOC.txt             mc-3-big-Filter.db           mc-3-big-TOC.txt
```

The current way of doing it is still preserved: 
```
ubuntu@ip-172-31-9-86:~$ tableslurp -n 172.31.9.86 --aws-region ap-northeast-2 lerhconsultest /cassandra/data/restoretest/perks-c375e720b21911e789d4671ea19485f1 backuptest/
tableslurp [2017-10-17 02:10:16,819] INFO Building fileset
tableslurp [2017-10-17 02:10:16,861] INFO Fileset contains 25 files to download
tableslurp [2017-10-17 02:10:16,914] INFO Will now try to test writing to the target dir backuptest/
tableslurp [2017-10-17 02:10:16,914] INFO Will write to backuptest/
tableslurp [2017-10-17 02:10:16,915] INFO Running
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-1-big-Summary.db onto queue
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-2-big-Data.db onto queue
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-3-big-Filter.db onto queue
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-2-big-Digest.crc32 onto queue
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-3-big-Summary.db onto queue
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-1-big-CompressionInfo.db onto queue
tableslurp [2017-10-17 02:10:16,915] INFO Pushing file mc-2-big-Index.db onto queue...
.....
tableslurp [2017-10-17 02:10:17,267] INFO Downloading 172.31.9.86:/cassandra/data/restoretest/perks-c375e720b21911e789d4671ea19485f1/mc-1-big-Index.db from lerhconsultest to backuptest/mc-1-big-Index.db
tableslurp [2017-10-17 02:10:17,278] INFO Thread #2 finished processing
tableslurp [2017-10-17 02:10:17,282] INFO Downloading 172.31.9.86:/cassandra/data/restoretest/perks-c375e720b21911e789d4671ea19485f1/mc-3-big-Data.db from lerhconsultest to backuptest/mc-3-big-Data.db
tableslurp [2017-10-17 02:10:17,288] INFO Downloading 172.31.9.86:/cassandra/data/restoretest/perks-c375e720b21911e789d4671ea19485f1/mc-3-big-TOC.txt from lerhconsultest to backuptest/mc-3-big-TOC.txt
tableslurp [2017-10-17 02:10:17,295] INFO Thread #3 finished processing
tableslurp [2017-10-17 02:10:17,305] INFO Thread #1 finished processing
tableslurp [2017-10-17 02:10:17,322] INFO Thread #0 finished processing
tableslurp [2017-10-17 02:10:17,322] INFO My job is done.
```

Giving: 
```
backuptest/
mc-1-big-CompressionInfo.db  mc-1-big-Statistics.db       mc-2-big-Digest.crc32        mc-2-big-TOC.txt             mc-3-big-Index.db            
mc-1-big-Data.db             mc-1-big-Summary.db          mc-2-big-Filter.db           mc-3-big-CompressionInfo.db  mc-3-big-Statistics.db      
mc-1-big-Digest.crc32        mc-1-big-TOC.txt             mc-2-big-Index.db            mc-3-big-Data.db             mc-3-big-Summary.db
mc-1-big-Filter.db           mc-2-big-CompressionInfo.db  mc-2-big-Statistics.db       mc-3-big-Digest.crc32        mc-3-big-TOC.txt
mc-1-big-Index.db            mc-2-big-Data.db             mc-2-big-Summary.db          mc-3-big-Filter.db           
```
The current way of doing it is a little bit finicky as mentioned in  https://github.com/JeremyGrosser/tablesnap/issues/57. I've also added a check to make `--recursive` and `-file` mutually exclusive. 

Thanks!