### PR TITLE
Added option to connect without AWS credentials

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -116,10 +116,12 @@ class UploadHandler(pyinotify.ProcessEvent):
                                            aws_access_key_id=self.key,
                                            aws_secret_access_key=self.secret,
                                            security_token=self.token)
-        else:
+        elif self.key and self.secret:
             s3 = boto.s3.connect_to_region(self.region,
                                            aws_access_key_id=self.key,
                                            aws_secret_access_key=self.secret)
+        else:
+            s3 = boto.s3.connect_to_region(self.region)
 
         return s3.get_bucket(self.bucket_name)
 
@@ -542,10 +544,13 @@ def main():
                                        aws_access_key_id=args.aws_key,
                                        aws_secret_access_key=args.aws_secret,
                                        security_token=args.aws_token)
-    else:
+    elif args.aws_key and args.aws_secret:
         s3 = boto.s3.connect_to_region(args.aws_region,
                                        aws_access_key_id=args.aws_key,
                                        aws_secret_access_key=args.aws_secret)
+    else:
+        s3 = boto.s3.connect_to_region(args.aws_region)
+
     bucket = s3.get_bucket(args.bucket)
 
     handler = UploadHandler(threads=args.threads, key=args.aws_key,


### PR DESCRIPTION
In case no aws key or secret are provided, the code will attempt to s3 without credentials. If the code is executed from an AWS server that has a IAM role associated with it, you can grant access to your bucket directly to the role and you don't have to keep any secrets on the server.

I've verified this worked on AWS when run from a server that has an IAM role associated with it, and that it doesn't break any of your tests. I don't see a way of actually testing this option locally, so I didn't modify any test code.

Closes #80.

Let me know what you think! And thanks for making this great package!