### PR TITLE
Ignore IN_CREATE events by default

### DIFF
--- a/tablesnap
+++ b/tablesnap
@@ -65,7 +65,7 @@ class UploadHandler(pyinotify.ProcessEvent):
                 log=default_log,
                 md5_on_start=False,
                 retries=1,
-                listen_events=default_listen_events):
+                listen_events=None):
         self.key = key
         self.secret = secret
         self.token = token
@@ -82,7 +82,7 @@ class UploadHandler(pyinotify.ProcessEvent):
         self.with_sse = with_sse
         self.delete_on_backup = delete_on_backup
         self.md5_on_start = md5_on_start
-        self.listen_events = listen_events
+        self.listen_events = listen_events or default_listen_events
 
         if max_size:
             self.max_size = max_size * 2**20

--- a/tablesnap
+++ b/tablesnap
@@ -64,7 +64,8 @@ class UploadHandler(pyinotify.ProcessEvent):
                 delete_on_backup=False,
                 log=default_log,
                 md5_on_start=False,
-                retries=1):
+                retries=1,
+                listen_events=default_listen_events):
         self.key = key
         self.secret = secret
         self.token = token
@@ -81,6 +82,7 @@ class UploadHandler(pyinotify.ProcessEvent):
         self.with_sse = with_sse
         self.delete_on_backup = delete_on_backup
         self.md5_on_start = md5_on_start
+        self.listen_events = listen_events
 
         if max_size:
             self.max_size = max_size * 2**20
@@ -146,7 +148,13 @@ class UploadHandler(pyinotify.ProcessEvent):
         self.add_file(event.pathname)
 
     def process_IN_CREATE(self, event):
-        self.add_file(event.pathname)
+        if 'IN_CREATE' in self.listen_events:
+            # If the --auto-add argument is specified when running tablesnap,
+            # the handler will be notified by pyinotify for IN_CREATE file
+            # events automatically, so they need to be ignored by the
+            # handler unless explicitly listened for (via the
+            # --listen-events) argument.
+            self.add_file(event.pathname)
     #
     # Check if this keyname (ie, file) has already been uploaded to
     # the S3 bucket. This will verify that not only does the keyname
@@ -562,7 +570,8 @@ def main():
                             max_size=int(args.max_upload_size),
                             chunk_size=int(args.multipart_chunk_size),
                             md5_on_start=args.md5_on_start,
-                            retries=(args.retries + 1))
+                            retries=(args.retries + 1),
+                            listen_events=args.listen_events)
 
     wm = pyinotify.WatchManager()
     notifier = pyinotify.Notifier(wm, handler)


### PR DESCRIPTION
`pyinotify` automatically notifies the tablesnap `UploadHandler` for `IN_CREATE` events if tablesnap is started with the `--auto-add` option, which causes all kinds of errors for tablesnap, since it starts copying the files to S3 before they are done being written. This pull request just adds a check that will prevent upload on `IN_CREATE` events unless that is directly specified via the `--listen-events` argument.

Let me know if this is the wrong way to fix this or if you see any other issues with this code.

This closes #91 